### PR TITLE
Refactoring the add tag api method to include fields and additional tags with a filter for customization.

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -486,6 +486,8 @@ class ConvertKit_PMP_Admin {
 			/**
 			 * Allow custom code to add additional fields for the subscriber.
 			 *
+			 * @since TBD
+			 *
 			 * @param array $subscribe_fields The array of fields to add for the subscriber.
 			 * @param string $user_email The user's email address to subscribe tags for.
 			 *

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -480,8 +480,6 @@ class ConvertKit_PMP_Admin {
 			 * @param string $user_email The user's email address to subscribe tags for.
 			 * @param array $new_levels The new level objects for this user.
 			 * @param array $old_levels The old level objects for this user.
-			 *
-			 * @return array The array of tag IDs to subscribe this email address to.
 			 */
 			$subscribe_tags = apply_filters( 'pmpro_convertkit_subscribe_tags', $subscribe_tags, $user_email, $new_levels, $old_levels );
 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -518,8 +518,6 @@ class ConvertKit_PMP_Admin {
 				 * @param string $user_email The user's email address to unsubscribe tags for.
 				 * @param array $new_levels The new level objects for this user.
 				 * @param array $old_levels The old level objects for this user.
-				 *
-				 * @return array The array of tag IDs to unsubscribe this email address from.
 				 */
 				$unsubscribe_tags = apply_filters( 'pmpro_convertkit_subscribe_tags', $unsubscribe_tags, $user_email, $new_levels, $old_levels );
 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -474,6 +474,8 @@ class ConvertKit_PMP_Admin {
 			/**
 			 * Allow custom code to filter the subscribe tags for the user by email.
 			 *
+			 * @since TBD
+			 *
 			 * @param array $subscribe_tags The array of tag IDs to subscribe this email address to.
 			 * @param string $user_email The user's email address to subscribe tags for.
 			 * @param array $new_levels The new level objects for this user.

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -490,8 +490,6 @@ class ConvertKit_PMP_Admin {
 			 *
 			 * @param array $subscribe_fields The array of fields to add for the subscriber.
 			 * @param string $user_email The user's email address to subscribe tags for.
-			 *
-			 * @return array The array of fields to add for the subscriber.
 			 */
 			$subscribe_fields = apply_filters( 'pmpro_convertkit_subscribe_fields', array(), $user_email );
 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -512,6 +512,8 @@ class ConvertKit_PMP_Admin {
 				/**
 				 * Allow custom code to filter the unsubscribe tags for the user by email.
 				 *
+				 * @since TBD
+				 *
 				 * @param array $unsubscribe_tags The array of tag IDs to unubscribe this email address from.
 				 * @param string $user_email The user's email address to unsubscribe tags for.
 				 * @param array $new_levels The new level objects for this user.

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -465,16 +465,35 @@ class ConvertKit_PMP_Admin {
 			// Build a unique array of tags to subscribe to contact and remove from contact.
 			$subscribe_tags = array_diff( $new_tags, $old_tags );
 			$unsubscribe_tags = array_diff( $old_tags, $new_tags );
-		
+
 			// Get the subscriber information.
 			$user = get_userdata( $user_id );
 			$user_email = $user->user_email;
 			$user_name = $user->first_name . ' ' . $user->last_name;
 
+			/**
+			 * Allow custom code to filter the subscribe tags for the user by email.
+			 *
+			 * @param array $subscribe_tags The array of tag IDs to subscribe this email address to.
+			 * @param string $user_email The user's email address to subscribe tags for.
+			 * @param array $new_levels The new level objects for this user.
+			 * @param array $old_levels The old level objects for this user.
+			 *
+			 * @return array The array of tag IDs to subscribe this email address to.
+			 */
+			$subscribe_tags = apply_filters( 'pmpro_convertkit_subscribe_tags', $subscribe_tags, $user_email, $new_levels, $old_levels );
+
+			/**
+			 * Allow custom code to add additional fields for the subscriber.
+			 *
+			 * @param array $subscribe_fields The array of fields to add for the subscriber.
+			 *
+			 * @return array The array of fields to add for the subscriber.
+			 */
+			$subscribe_fields = apply_filters( 'pmpro_convertkit_subscribe_fields', array(), $user_email );
+
 			// Run the API call to add tag to this subscriber.
-			foreach ( $subscribe_tags as $subscribe_tag ) {
-				$this->api->add_tag_to_user( $user_email, $user_name, $subscribe_tag );
-			}
+			$this->api->add_tag_to_user( $user_email, $user_name, $subscribe_tags, $subscribe_fields );
 
 			/**
 			 * Option to remove other tags for other levels on level change.
@@ -487,13 +506,25 @@ class ConvertKit_PMP_Admin {
 			$remove_tags = apply_filters( 'pmpro_convertkit_after_all_membership_level_changes_remove_tags', false, $unsubscribe_tags );
 			
 			if ( ! empty( $remove_tags ) ) {
+				/**
+				 * Allow custom code to filter the unsubscribe tags for the user by email.
+				 *
+				 * @param array $unsubscribe_tags The array of tag IDs to unubscribe this email address from.
+				 * @param string $user_email The user's email address to unsubscribe tags for.
+				 * @param array $new_levels The new level objects for this user.
+				 * @param array $old_levels The old level objects for this user.
+				 *
+				 * @return array The array of tag IDs to unsubscribe this email address from.
+				 */
+				$unsubscribe_tags = apply_filters( 'pmpro_convertkit_subscribe_tags', $unsubscribe_tags, $user_email, $new_levels, $old_levels );
+
 				// Get the secret API key.
 				$api_secret_key = $this->get_option( 'api-secret-key' );
 
 				// Run the API call to remove tags from this subscriber.
 				if ( ! empty ( $unsubscribe_tags ) && ! empty ( $api_secret_key ) ) {
 					foreach ( $unsubscribe_tags as $unsubscribe_tag ) {
-						$this->api->remove_tag_from_user( $user_email, $api_secret_key, $unsubscribe_tag );
+						$this->api->remove_tag_from_user( $user_email, $api_secret_key, $unsubscribe_tags );
 					}
 				}
 			}

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -487,6 +487,7 @@ class ConvertKit_PMP_Admin {
 			 * Allow custom code to add additional fields for the subscriber.
 			 *
 			 * @param array $subscribe_fields The array of fields to add for the subscriber.
+			 * @param string $user_email The user's email address to subscribe tags for.
 			 *
 			 * @return array The array of fields to add for the subscriber.
 			 */

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -108,10 +108,10 @@ class ConvertKit_PMP_API {
 	 *
 	 * @param string $user_email
 	 * @param string $user_name
-	 * @param int $tag_id
+	 * @param array $subscribe_tags
+	 * @param array $subscribe_fields
 	 */
-	public function add_tag_to_user( $user_email, $user_name, $tag_id ) {
-
+	public function add_tag_to_user( $user_email, $user_name, $subscribe_tags, $subscribe_fields ) {
 		// Get the API key.
 		$api_key = $this->api_key;
 		if ( '' == $api_key ) {
@@ -124,9 +124,23 @@ class ConvertKit_PMP_API {
 			'email' => $user_email,
 		);
 
+		// If there are custom fields, add them to the body of the API request.
+		if ( ! empty( $subscribe_fields ) ) {
+			$args['fields'] = $subscribe_fields;
+		}
+
+		// If there is more than one tag, add the rest as additional tags in the body of the API request.
+		if ( count( $subscribe_tags ) > 1 ) {
+			$primary_tag_id = array_shift( $subscribe_tags );
+			$args['tags'] = $subscribe_tags;
+		} else {
+			// Set the primary tag ID for the API request to the only item in the array of $subscribe_tags.
+			$primary_tag_id = array_values( $subscribe_tags )[0];
+		}
+
 		// Build the request URL.
 		$query_args = array();
-		$request_url = $this->api_url . '/' . $this->api_version . '/tags/' . $tag_id . '/subscribe';
+		$request_url = $this->api_url . '/' . $this->api_version . '/tags/' . $primary_tag_id . '/subscribe';
 		$query_args['api_key'] = $api_key;
 		$request_url = add_query_arg( $query_args, $request_url );
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -140,7 +140,7 @@ class ConvertKit_PMP_API {
 
 		// Build the request URL.
 		$query_args = array();
-		$request_url = $this->api_url . '/' . $this->api_version . '/tags/' . $primary_tag_id . '/subscribe';
+		$request_url = $this->api_url . '/' . $this->api_version . '/tags/' . intval( $primary_tag_id ) . '/subscribe';
 		$query_args['api_key'] = $api_key;
 		$request_url = add_query_arg( $query_args, $request_url );
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -135,7 +135,7 @@ class ConvertKit_PMP_API {
 			$args['tags'] = $subscribe_tags;
 		} else {
 			// Set the primary tag ID for the API request to the only item in the array of $subscribe_tags.
-			$primary_tag_id = array_values( $subscribe_tags )[0];
+			$primary_tag_id = reset( $subscribe_tags );
 		}
 
 		// Build the request URL.


### PR DESCRIPTION
The updated v3 api from ConvertKit now includes additional tags in the same API call (previously you needed to do one call per tag to add). This update now allows custom code to add fields and add additional tags via new filters:
- `pmpro_convertkit_subscribe_tags`
- `pmpro_convertkit_subscribe_fields`

An example of these using these filters is shown below:

`function convertkit_add_tag_based_on_opt_in( $subscribe_tags, $user_email, $new_levels, $old_levels ) {
	// Get the user and look up whether they opted in to the welcome series.
	$user = get_user_by( 'email', $user_email );
	if ( ! empty( $user ) && ! empty( $user->ID ) ) {
		$welcomeseries = get_user_meta( $user->ID, 'welcomeseries', true );
	}

	// Add additional tags based on opt in.
	if ( empty( $welcomeseries ) ) {
		// Add the nowelcomeseries tag.
		$subscribe_tags[] = '2768503';
	} else {
		// Add the welcomeseries tag.
		$subscribe_tags[] = '2452711';
	}

	// Return the updated tags.
	return $subscribe_tags;
}
add_filter( 'pmpro_convertkit_subscribe_tags', 'convertkit_add_tag_based_on_opt_in', 10, 4 );`

`function my_convertkit_add_fields_to_subscriber( $subscribe_fields, $user_email ) {
	// Get the user and add their last name to the fields.
	$user = get_user_by( 'email', $user_email );
	if ( ! empty( $user ) && ! empty( $user->ID ) ) {
		$subscribe_fields['last_name'] = $user->last_name;
	}

	// Return the updated fields.
	return $subscribe_fields;
}
add_filter( 'pmpro_convertkit_subscribe_fields', 'my_convertkit_add_fields_to_subscriber', 10, 4 );
`