### PR TITLE
Typo with new filter name for unsubscribe additional tags to remove.

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -517,7 +517,7 @@ class ConvertKit_PMP_Admin {
 				 * @param array $new_levels The new level objects for this user.
 				 * @param array $old_levels The old level objects for this user.
 				 */
-				$unsubscribe_tags = apply_filters( 'pmpro_convertkit_subscribe_tags', $unsubscribe_tags, $user_email, $new_levels, $old_levels );
+				$unsubscribe_tags = apply_filters( 'pmpro_convertkit_unsubscribe_tags', $unsubscribe_tags, $user_email, $new_levels, $old_levels );
 
 				// Get the secret API key.
 				$api_secret_key = $this->get_option( 'api-secret-key' );

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -525,7 +525,7 @@ class ConvertKit_PMP_Admin {
 				// Run the API call to remove tags from this subscriber.
 				if ( ! empty ( $unsubscribe_tags ) && ! empty ( $api_secret_key ) ) {
 					foreach ( $unsubscribe_tags as $unsubscribe_tag ) {
-						$this->api->remove_tag_from_user( $user_email, $api_secret_key, $unsubscribe_tags );
+						$this->api->remove_tag_from_user( $user_email, $api_secret_key, $unsubscribe_tag );
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Small typo with a new filter name - should have been `pmpro_convertkit_unsubscribe_tags`.
