### PR TITLE
Storing subscriber ID in user meta

### DIFF
--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -252,12 +252,7 @@ class ConvertKit_PMP_API {
 			$purchase = json_decode( $request['body'] );
 			add_pmpro_membership_order_meta( $order->id, 'convertkit_pmp_purchase_id', $purchase->id );			
 
-			//Get the subscriber
-			$subscriber = $this->get_subscriber( $user_email, $api_secret_key );
-			//Use the subscriber ID and add to user meta
-			if( !empty( $subscriber->id ) ) {
-				update_user_meta( $order->user_id, 'pmprock_subscriber_id', $subscriber->id );
-			}
+			$this->get_subscriber_id( $user_email, $api_secret_key, $order->user_id );
 		}
 
 		if ( defined( 'CK_DEBUG') ) {
@@ -313,6 +308,37 @@ class ConvertKit_PMP_API {
 			$this->log( "Request url: " . $request_url );
 			$this->log( "Request args: " . print_r( $args, true ) );
 		}
+
+	}
+
+	/**
+	 * Gets the subscriber ID and updates it in user meta if necessary
+	 * 
+	 * @param string $user_email
+	 * @param string $api_secret_key	 
+	 *
+	 * @since TBD
+	 *
+	 * @return string|void
+	 */
+	public function get_subscriber_id( $user_email, $api_secret_key, $user_id ) {
+
+		//Check if we have a subscriber ID in user meta first
+		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', $subscriber->id );
+
+		if( empty( $subscriber_id ) ) {
+
+			//Get the subscriber
+			$subscriber = $this->get_subscriber( $user_email, $api_secret_key );
+			//Use the subscriber ID and add to user meta
+			if( !empty( $subscriber->id ) ) {
+				update_user_meta( $order->user_id, 'pmprock_subscriber_id', $subscriber->id );
+				return $subscriber->id;
+			}
+
+		}
+
+		return $subscriber_id;
 
 	}
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -247,7 +247,7 @@ class ConvertKit_PMP_API {
 				)
 			)
 		);
-		// error_log( print_r( $request, true ) );
+		
 		if ( ! is_wp_error( $request ) && function_exists( 'add_pmpro_membership_order_meta' ) ) {
 			$purchase = json_decode( $request['body'] );
 			add_pmpro_membership_order_meta( $order->id, 'convertkit_pmp_purchase_id', $purchase->id );			
@@ -266,6 +266,16 @@ class ConvertKit_PMP_API {
 		}
 	}
 
+	/**
+	 * Search for a subscriber by email address
+	 * 
+	 * @param string $user_email
+	 * @param string $api_secret_key	 
+	 *
+	 * @since TBD
+	 *
+	 * @return bool|void
+	 */
 	public function get_subscriber( $user_email, $api_secret_key ) {
 
 		/**

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -252,7 +252,9 @@ class ConvertKit_PMP_API {
 			$purchase = json_decode( $request['body'] );
 			add_pmpro_membership_order_meta( $order->id, 'convertkit_pmp_purchase_id', $purchase->id );			
 
-			$this->get_subscriber_id( $user_email, $api_secret_key, $order->user_id );
+			$subscriber_id = $this->get_subscriber_id( $user_email, $api_secret_key, $order->user_id );
+
+			update_user_meta( $order->user_id, 'pmprock_subscriber_id', $subscriber_id );
 		}
 
 		if ( defined( 'CK_DEBUG') ) {
@@ -319,7 +321,7 @@ class ConvertKit_PMP_API {
 	 *
 	 * @since TBD
 	 *
-	 * @return string|void
+	 * @return string
 	 */
 	public function get_subscriber_id( $user_email, $api_secret_key, $user_id ) {
 
@@ -331,8 +333,7 @@ class ConvertKit_PMP_API {
 			//Get the subscriber
 			$subscriber = $this->get_subscriber( $user_email, $api_secret_key );
 			//Use the subscriber ID and add to user meta
-			if( !empty( $subscriber->id ) ) {
-				update_user_meta( $order->user_id, 'pmprock_subscriber_id', $subscriber->id );
+			if( !empty( $subscriber->id ) ) {				
 				return $subscriber->id;
 			}
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -247,16 +247,63 @@ class ConvertKit_PMP_API {
 				)
 			)
 		);
-
+		// error_log( print_r( $request, true ) );
 		if ( ! is_wp_error( $request ) && function_exists( 'add_pmpro_membership_order_meta' ) ) {
 			$purchase = json_decode( $request['body'] );
-			add_pmpro_membership_order_meta( $order->id, 'convertkit_pmp_purchase_id', $purchase->id );
+			add_pmpro_membership_order_meta( $order->id, 'convertkit_pmp_purchase_id', $purchase->id );			
+
+			//Get the subscriber
+			$subscriber = $this->get_subscriber( $user_email, $api_secret_key );
+			//Use the subscriber ID and add to user meta
+			if( !empty( $subscriber->id ) ) {
+				update_user_meta( $order->user_id, 'pmprock_subscriber_id', $subscriber->id );
+			}
 		}
 
 		if ( defined( 'CK_DEBUG') ) {
 			$this->log( "Request url: " . $request_url );
 			$this->log( "Request args: " . print_r( $args, true ) );
 		}
+	}
+
+	public function get_subscriber( $user_email, $api_secret_key ) {
+
+		/**
+		 * Using the subscribers search endpoint to get the subscriber's ID		 
+		 */
+		$args = array(
+			'api_secret' => $api_secret_key,
+			'email_address' => sanitize_email( $user_email )
+		);
+		
+		// Build the request URL.
+		$request_url = $this->api_url . '/' . $this->api_version . '/subscribers';
+
+		// Send the data to ConvertKit.
+		$request = wp_remote_get(
+			$request_url,
+			array(
+				'body'    => $args,
+				'timeout' => 30,
+			)
+		);
+		
+		if ( ! is_wp_error( $request ) ) {
+			
+			$results = json_decode( $request['body'] );
+			
+			if( !empty( $results->subscribers ) ) {
+				//Return the first subscriber only
+				return reset( $results->subscribers );
+			}
+			
+		}
+
+		if ( defined( 'CK_DEBUG') ) {
+			$this->log( "Request url: " . $request_url );
+			$this->log( "Request args: " . print_r( $args, true ) );
+		}
+
 	}
 
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -299,7 +299,7 @@ class ConvertKit_PMP_API {
 			
 			$results = json_decode( $request['body'] );
 			
-			if( !empty( $results->subscribers ) ) {
+			if ( ! empty( $results->subscribers ) ) {
 				//Return the first subscriber only
 				return reset( $results->subscribers );
 			}
@@ -328,12 +328,12 @@ class ConvertKit_PMP_API {
 		//Check if we have a subscriber ID in user meta first
 		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', $subscriber->id );
 
-		if( empty( $subscriber_id ) ) {
+		if ( empty( $subscriber_id ) ) {
 
 			//Get the subscriber
 			$subscriber = $this->get_subscriber( $user_email, $api_secret_key );
 			//Use the subscriber ID and add to user meta
-			if( !empty( $subscriber->id ) ) {				
+			if ( ! empty( $subscriber->id ) ) {				
 				return $subscriber->id;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We now record the subscriber ID during checkout and store it in user meta

Resolve #7

### How to test the changes in this Pull Request:

1. Set up CK for PMPro
2. Checkout and make sure you are subscribed to your CK list
3. Your subscriber ID will be stored in user meta with the meta key pmprock_subscriber_id

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Storing the subscriber ID will be used for more new functionality