### PR TITLE
Added the option to add non-member tags

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -354,8 +354,8 @@ class ConvertKit_PMP_Admin {
 		$require_opt_in = $this->get_option( 'opt-in-non-members' );
 
 		?><input type="checkbox" id="<?php echo $this->plugin_name; ?>-options[opt-in-non-members]" name="<?php echo $this->plugin_name; ?>-options[opt-in-non-members]" <?php checked( $require_opt_in, 'yes' ); ?> value="yes" />
-		<label for="<?php echo $this->plugin_name; ?>-options[opt-in-non-members]"><?php esc_html_e( 'Display an opt-in checkbox on Membership Checkout' ); ?></label>
-		<p class="description"><?php esc_html_e( 'If enabled, members will only be subscribed and tagged in ConvertKit if the "opt-in" checkbox presented on checkout is checked.', 'convertkit-pmp' ); ?></p><?php
+		<label for="<?php echo $this->plugin_name; ?>-options[opt-in-non-members]"><?php esc_html_e( 'Automatically add a tag to non-members upon cancelling their membership' ); ?></label>
+		<p class="description"><?php esc_html_e( 'Select the tag you would like added to non-members under the "Assign Tags" section below.', 'convertkit-pmp' ); ?></p><?php
 	}	
 
 	/**
@@ -511,11 +511,18 @@ class ConvertKit_PMP_Admin {
 			 * If opt-in for non-members is enabled, we'll add a 'Non-member' tag
 			 * to the subscriber.
 			 */
-			if( empty( $new_levels ) ) {				
+			if( empty( $new_levels ) ) {
+
 				$opt_in_non_members = $this->get_option( 'opt-in-non-members' );
 
 				if( !empty( $opt_in_non_members ) ) {
-					$subscribe_tags[] = $this->get_option( 'convertkit-mapping-0' );
+
+					$non_members_tag = $this->get_option( 'convertkit-mapping-0' );
+
+					if( !empty( $non_members_tag ) ) {
+						$subscribe_tags[] = $this->get_option( 'convertkit-mapping-0' );
+					}
+
 				}
 			}
 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -385,7 +385,10 @@ class ConvertKit_PMP_Admin {
 				?>
 				<option value="<?php echo $value; ?>" <?php selected( $tag, $value ); ?>><?php echo $text; ?></option><?php
 			}
-			?></select><?php
+			?></select><?php			
+			if( $args['key'] === 0 ) {
+				printf( "<p class='description'>%s</p>", __( "This tag will be assigned when a member's level is removed", "convertkit-pmp" ) );
+			}
 		}
 
 	}

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -386,8 +386,8 @@ class ConvertKit_PMP_Admin {
 				<option value="<?php echo $value; ?>" <?php selected( $tag, $value ); ?>><?php echo $text; ?></option><?php
 			}
 			?></select><?php			
-			if( $args['key'] === 0 ) {
-				printf( "<p class='description'>%s</p>", __( "This tag will be assigned when a member's level is removed", "convertkit-pmp" ) );
+			if ( $args['key'] === 0 ) {
+				printf( "<p class='description'><small>%s</small></p>", esc_html( "This tag will be assigned when a member's level is removed.", "convertkit-pmp" ) );
 			}
 		}
 

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -326,7 +326,7 @@ class ConvertKit_PMP_API {
 	public function get_subscriber_id( $user_email, $api_secret_key, $user_id ) {
 
 		//Check if we have a subscriber ID in user meta first
-		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', $subscriber->id );
+		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', true );
 
 		if ( empty( $subscriber_id ) ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds in the ability to add a tag of your choice to non-members. 

Resolves #5

### How to test the changes in this Pull Request:

1. Navigate to /wp-admin/options-general.php?page=convertkit-pmp
2. Enable the checkbox Opt-In Non-members
3. Select your preferred tag under the 'Assign tags' section for 'Non-members

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement: You can now tag non-members