### PR TITLE
Detect API Key changes - Clear transients

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -183,14 +183,8 @@ class ConvertKit_PMP_Admin {
 	public function updated_options( $option, $old_value, $new_value ) {
 
 		if( $option == 'convertkit-pmp-options' ) {
-			
-			$old_api_key = ! empty( $old_value['api-key'] ) ? $old_value['api-key'] : '';
-			$new_api_key = ! empty( $new_value['api-key'] ) ? $new_value['api-key'] : '';
-
-			if( $new_api_key != $old_api_key ) {
-				//The API Key has changed. Clear transients to use the new API key
-				delete_transient( 'convertkit_pmp_tag_data' );
-			}
+			//Clear transients when saving the settings to ensure tags are updated
+			delete_transient( 'convertkit_pmp_tag_data' );
 		}
 
 	}

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -174,6 +174,27 @@ class ConvertKit_PMP_Admin {
 
 	}
 
+	/**
+	 * Detect if the API key has changed and clear transient data if needed
+	 *
+	 * @since       TBD
+	 * @return      void
+	 */
+	public function updated_options( $option, $old_value, $new_value ) {
+
+		if( $option == 'convertkit-pmp-options' ) {
+			
+			$old_api_key = ! empty( $old_value['api-key'] ) ? $old_value['api-key'] : '';
+			$new_api_key = ! empty( $new_value['api-key'] ) ? $new_value['api-key'] : '';
+
+			if( $new_api_key != $old_api_key ) {
+				//The API Key has changed. Clear transients to use the new API key
+				delete_transient( 'convertkit_pmp_tag_data' );
+			}
+		}
+
+	}
+
 
 	/**
 	 * Adds a settings page link to a menu

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -83,8 +83,11 @@ class ConvertKit_PMP_API {
 
 			if ( ! is_wp_error( $data ) ) {
 				$tags = json_decode( $data['body'] );
-				$tags = $tags->tags;
-				set_transient( 'convertkit_pmp_tag_data', $tags, 24*24 );
+				
+				if( ! empty( $tags->tags ) ) {
+					$tags = $tags->tags;					
+					set_transient( 'convertkit_pmp_tag_data', $tags, 24*24 );
+				}
 			}
 
 			if ( defined( 'CK_DEBUG') ) {
@@ -93,7 +96,7 @@ class ConvertKit_PMP_API {
 
 		}
 
-		if ( ! empty( $tags ) ) {
+		if ( ! empty( $tags ) && empty( $tags->error ) ) {
 			foreach( $tags as $key => $tag ) {
 				$this->tags[ $tag->id ] = $tag->name;
 			}

--- a/includes/class-convertkit-pmp.php
+++ b/includes/class-convertkit-pmp.php
@@ -148,6 +148,7 @@ class ConvertKit_PMP {
 		$this->loader->add_filter( 'plugin_action_links_convertkit-paid-memberships-pro/convertkit-pmp.php' , $plugin_admin, 'settings_link' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+		$this->loader->add_action( 'updated_option', $plugin_admin, 'updated_options', 10, 3 );
 		$this->loader->add_action( 'pmpro_after_all_membership_level_changes', $plugin_admin, 'after_all_membership_level_changes', 10, 3 );
 		$this->loader->add_action( 'pmpro_checkout_after_tos_fields', $plugin_admin, 'after_tos_fields', 10, 1 );
 		$this->loader->add_action( 'pmpro_paypalexpress_session_vars', $plugin_admin, 'paypalexpress_session_vars', 10, 1 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks when saving settings if the API key has changed. If it has, we delete the transient for tags to ensure new tags can be obtained.

Resolves #3 

### How to test the changes in this Pull Request:

1. Set up your API key
2. Tags will load on the page after saving
3. Change the API key - new tags should show

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Tag data is refreshed after changing API Key