### PR TITLE
Filter added to error log file path

### DIFF
--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -326,7 +326,7 @@ class ConvertKit_PMP_API {
 	public function get_subscriber_id( $user_email, $api_secret_key, $user_id ) {
 
 		//Check if we have a subscriber ID in user meta first
-		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', $subscriber->id );
+		$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', true );
 
 		if ( empty( $subscriber_id ) ) {
 
@@ -352,7 +352,10 @@ class ConvertKit_PMP_API {
 	 */
 	public function log( $message ) {
 
-		$log     = fopen( plugin_dir_path( __FILE__ ) . '/log.txt', 'a+' );
+		//By default this points to \plugins\convertkit-paid-memberhips-pro\includes/log.txt
+		$pmprock_log_file = apply_filters( 'pmprock_logfile', plugin_dir_path( __FILE__ ) . 'log.txt' );
+
+		$log     = fopen( $pmprock_log_file, 'a+' );
 		$message = '[' . date( 'd-m-Y H:i:s' ) . '] ' . $message . PHP_EOL;
 		fwrite( $log, $message );
 		fclose( $log );

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -352,7 +352,15 @@ class ConvertKit_PMP_API {
 	 */
 	public function log( $message ) {
 
-		//By default this points to \plugins\convertkit-paid-memberhips-pro\includes/log.txt
+		/**
+		 * Filter the debug log file. 
+		 * By default this points to \plugins\convertkit-paid-memberhips-pro\includes/log.txt
+		 * 
+		 * @param string $path
+		 *
+		 * @since TBD
+		 *		 
+		 */
 		$pmprock_log_file = apply_filters( 'pmprock_logfile', plugin_dir_path( __FILE__ ) . 'log.txt' );
 
 		$log     = fopen( $pmprock_log_file, 'a+' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #8

### How to test the changes in this Pull Request:

1. Steps on how to reproduce found in issue #8
2. By default, logs are stored in the includes folder, I've added a filter to the path so that it can be changed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Filter added to debug log path