### PR TITLE
Opt-in label field will now show/hide based on the selected checkbox

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -117,7 +117,8 @@ class ConvertKit_PMP_Admin {
 			apply_filters( $this->plugin_name . '-require-opt-in', __( 'Require Opt-In', 'convertkit-pmp' ) ),
 			array( $this, 'display_options_require_opt_in' ),
 			$this->plugin_name,
-			$this->plugin_name . '-display-options'
+			$this->plugin_name . '-display-options',
+			array( 'class' => 'convertkit_pmp_require_opt_in' )
 		);
 
 		// add_settings_field( $id, $title, $callback, $menu_slug, $section, $args );
@@ -126,7 +127,8 @@ class ConvertKit_PMP_Admin {
 			apply_filters( $this->plugin_name . '-require-opt-in-label', __( 'Require Opt-In Label', 'convertkit-pmp' ) ),
 			array( $this, 'display_options_require_opt_in_label' ),
 			$this->plugin_name,
-			$this->plugin_name . '-display-options'
+			$this->plugin_name . '-display-options',
+			array( 'class' => 'convertkit_hide' )
 		);
 
 		// add_settings_section( $id, $title, $callback, $menu_slug );
@@ -730,4 +732,44 @@ class ConvertKit_PMP_Admin {
 		}
 		return $links;
 	}
+
+
+	/**
+	 * Add show and hide JS to the settings page for specific fields
+	 *
+	 * @since   TBD
+	 * @return	string - Javascript code
+	 */
+	public function admin_inline_script() {
+
+		if( !empty( $_REQUEST['page'] ) && $_REQUEST['page'] == 'convertkit-pmp' ) {
+
+			$script = "";
+
+			$script .= "<script type='text/javascript'>\n";
+			$script .= "jQuery(document).ready(function(){\n";
+			$script .= "
+			if( jQuery( '.convertkit_pmp_require_opt_in input' ).is( ':checked' ) ) {
+				jQuery( '.convertkit_hide' ).show();
+			} else {
+				jQuery( '.convertkit_hide' ).hide();
+			}
+			jQuery('body').on('click', '.convertkit_pmp_require_opt_in input', function(){
+				if( jQuery(this).is(':checked' ) ) {
+					jQuery( '.convertkit_hide' ).show();
+				} else {
+					jQuery( '.convertkit_hide' ).hide();
+				}
+				
+		    });";
+			$script .= "\n});"; 
+			$script .= "\n</script>"; 
+
+			echo $script;
+
+		}
+
+	}
+
+
 }

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -317,7 +317,25 @@ class ConvertKit_PMP_Admin {
 
 		?><input type="checkbox" id="<?php echo $this->plugin_name; ?>-options[require-opt-in]" name="<?php echo $this->plugin_name; ?>-options[require-opt-in]" <?php checked( $require_opt_in, 'yes' ); ?> value="yes" />
 		<label for="<?php echo $this->plugin_name; ?>-options[require-opt-in]"><?php esc_html_e( 'Display an opt-in checkbox on Membership Checkout' ); ?></label>
-		<p class="description"><?php esc_html_e( 'If enabled, members will only be subscribed and tagged in ConvertKit if the "opt-in" checkbox presented on checkout is checked.', 'convertkit-pmp' ); ?></p><?php
+		<p class="description"><?php esc_html_e( 'If enabled, members will only be subscribed and tagged in ConvertKit if the "opt-in" checkbox presented on checkout is checked.', 'convertkit-pmp' ); ?></p>
+		<script type='text/javascript'>
+		jQuery(document).ready(function(){
+			if( jQuery( '.convertkit_pmp_require_opt_in input' ).is( ':checked' ) ) {
+				jQuery( '.convertkit_hide' ).show();
+			} else {
+				jQuery( '.convertkit_hide' ).hide();
+			}
+			jQuery('body').on('click', '.convertkit_pmp_require_opt_in input', function(){
+				if( jQuery(this).is(':checked' ) ) {
+					jQuery( '.convertkit_hide' ).show();
+				} else {
+					jQuery( '.convertkit_hide' ).hide();
+				}
+				
+		    });
+		});
+		</script>
+		<?php
 	}
 
 
@@ -732,44 +750,5 @@ class ConvertKit_PMP_Admin {
 		}
 		return $links;
 	}
-
-
-	/**
-	 * Add show and hide JS to the settings page for specific fields
-	 *
-	 * @since   TBD
-	 * @return	string - Javascript code
-	 */
-	public function admin_inline_script() {
-
-		if( !empty( $_REQUEST['page'] ) && $_REQUEST['page'] == 'convertkit-pmp' ) {
-
-			$script = "";
-
-			$script .= "<script type='text/javascript'>\n";
-			$script .= "jQuery(document).ready(function(){\n";
-			$script .= "
-			if( jQuery( '.convertkit_pmp_require_opt_in input' ).is( ':checked' ) ) {
-				jQuery( '.convertkit_hide' ).show();
-			} else {
-				jQuery( '.convertkit_hide' ).hide();
-			}
-			jQuery('body').on('click', '.convertkit_pmp_require_opt_in input', function(){
-				if( jQuery(this).is(':checked' ) ) {
-					jQuery( '.convertkit_hide' ).show();
-				} else {
-					jQuery( '.convertkit_hide' ).hide();
-				}
-				
-		    });";
-			$script .= "\n});"; 
-			$script .= "\n</script>"; 
-
-			echo $script;
-
-		}
-
-	}
-
 
 }

--- a/includes/class-convertkit-pmp.php
+++ b/includes/class-convertkit-pmp.php
@@ -156,6 +156,7 @@ class ConvertKit_PMP {
 		$this->loader->add_action( 'personal_options_update', $plugin_admin, 'update_profile', 10, 2 );
 		$this->loader->add_action( 'edit_user_profile_update', $plugin_admin, 'update_profile', 10, 2 );
 		$this->loader->add_action( 'plugin_row_meta', $plugin_admin, 'plugin_row_meta', 10, 2 );
+		$this->loader->add_action( 'in_admin_footer', $plugin_admin, 'admin_inline_script', 20 );
 
 	}
 

--- a/includes/class-convertkit-pmp.php
+++ b/includes/class-convertkit-pmp.php
@@ -156,7 +156,6 @@ class ConvertKit_PMP {
 		$this->loader->add_action( 'personal_options_update', $plugin_admin, 'update_profile', 10, 2 );
 		$this->loader->add_action( 'edit_user_profile_update', $plugin_admin, 'update_profile', 10, 2 );
 		$this->loader->add_action( 'plugin_row_meta', $plugin_admin, 'plugin_row_meta', 10, 2 );
-		$this->loader->add_action( 'in_admin_footer', $plugin_admin, 'admin_inline_script', 20 );
 
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When clicking on the opt-in checkbox, the label field will show and hide.

### How to test the changes in this Pull Request:

1. Navigate to Settings > PMPro ConvertKit
2. Click on the Opt-In checkbox
3. The opt-in label will show and hide

Unchecked
![image](https://user-images.githubusercontent.com/8989542/172783129-0e7a4cfa-abe5-403c-9817-f74c8d2e2028.png)

Checked
![image](https://user-images.githubusercontent.com/8989542/172783173-59fd00d9-6332-4665-afa7-c21227d798dc.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement: UX changes to the Opt-in checkbox