### PR TITLE
Fixes a PHP error when no tags are present

### DIFF
--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -95,8 +95,8 @@ class ConvertKit_PMP_API {
 			}
 
 		}
-
-		if ( ! empty( $tags ) && empty( $tags->error ) ) {
+        //$tags returns an array when valid but an object with a tag property if empty
+		if ( ! empty( $tags ) && empty( $tags->error ) && is_array( $tags ) ) {
 			foreach( $tags as $key => $tag ) {
 				$this->tags[ $tag->id ] = $tag->name;
 			}

--- a/includes/class-convertkit-pmp-api.php
+++ b/includes/class-convertkit-pmp-api.php
@@ -95,8 +95,8 @@ class ConvertKit_PMP_API {
 			}
 
 		}
-        //$tags returns an array when valid but an object with a tag property if empty
-		if ( ! empty( $tags ) && empty( $tags->error ) && is_array( $tags ) ) {
+		// Check if $tags is a non-empty array and there's no error
+		if ( is_array( $tags ) && ! empty( $tags ) && empty( $tags->error ) ) {
 			foreach( $tags as $key => $tag ) {
 				$this->tags[ $tag->id ] = $tag->name;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a PHP error in the WP Admin dashboard when no tags are present in the CK account

### How to test the changes in this Pull Request:

1. Connect your CK API keys and ensure that you have no tags associated with the account
2. No errors should be present, and no dropdowns rendered for empty tags

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
