### PR TITLE
New filter `pmpro_convertkit_disable_create_purchase` to disable crea…

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -687,6 +687,16 @@ class ConvertKit_PMP_Admin {
 			return;		
 		}
 
+		/**
+		 * Filter to disable creating a purchase in ConvertKit for this order.
+		 *
+		 * @since TBD
+		 * @param bool $disable_create_purchase Set to true to disable creating a purchase in ConvertKit for this order.
+		 */
+		if ( apply_filters( 'pmpro_convertkit_disable_create_purchase', false, $order ) ) {
+			return;
+		}
+
 		// Send order details to ConvertKit if opt-in not required or if the user has agreed.
 		if ( empty( $require_opt_in ) || ( ! empty( $require_opt_in ) && ! empty( $_REQUEST['convertkit_pmp_require_opt_in'] ) ) ) {
 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -688,12 +688,12 @@ class ConvertKit_PMP_Admin {
 		}
 
 		/**
-		 * Filter to disable creating a purchase in ConvertKit for this order.
+		 * Filter whether to create a purchase in ConvertKit for this order.
 		 *
 		 * @since TBD
-		 * @param bool $disable_create_purchase Set to true to disable creating a purchase in ConvertKit for this order.
+		 * @param bool $create_purchase Set to false to disable creating a purchase in ConvertKit for this order.
 		 */
-		if ( apply_filters( 'pmpro_convertkit_disable_create_purchase', false, $order ) ) {
+		if ( ! apply_filters( 'pmpro_convertkit_create_purchase', true, $order ) ) {
 			return;
 		}
 


### PR DESCRIPTION
…ting a purchase in CK for order

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds a new filter `pmpro_convertkit_disable_create_purchase` that passes the order object so sites can turn off all purchase tracking or just disable for certain cases (by level ID, by amount, by gateway, etc).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added filter `pmpro_convertkit_disable_create_purchase` to disable creating purchases in ConvertKit after checkout.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.