### PR TITLE
Only set first name to the users first name or display name depending…

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -519,7 +519,9 @@ class ConvertKit_PMP_Admin {
 			// Get the subscriber information.
 			$user = get_userdata( $user_id );
 			$user_email = $user->user_email;
-			$user_name = $user->first_name . ' ' . $user->last_name;
+
+			// Set the user's first name to the user's first name if available, otherwise use the user's display name.
+			$user_name = isset( $user->first_name ) ? $user->first_name : $user->display_name;
 
 			/**
 			 * No new levels so we're assuming they're cancelling. 

--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -521,7 +521,7 @@ class ConvertKit_PMP_Admin {
 			$user_email = $user->user_email;
 
 			// Set the user's first name to the user's first name if available, otherwise use the user's display name.
-			$user_name = isset( $user->first_name ) ? $user->first_name : $user->display_name;
+			$user_name = empty( $user->first_name ) ? $user->display_name : $user->first_name;
 
 			/**
 			 * No new levels so we're assuming they're cancelling. 


### PR DESCRIPTION
… on what we have available

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We should only set the subscriber's "First Name" to their user First Name (if available). Since a name is required in the API, we will fall back to display_name since that is always set on a WP user.

Closes Issue: #28 

### Changelog entry
* BUG FIX/ENHANCEMENT: Updated logic for $user_name to use the first name if available, otherwise falling back to the display name.
