### PR TITLE
Fixing the method to update subscriber info when profiles are updated

### DIFF
--- a/admin/class-convertkit-pmp-admin.php
+++ b/admin/class-convertkit-pmp-admin.php
@@ -708,46 +708,54 @@ class ConvertKit_PMP_Admin {
 		}
 	}
 
-	/**		
- 	 * Updates a subscriber's details upon updating a user profile in wp-admin		
- 	 *		
- 	 * @access public		
- 	 * @since 1.2.0		
- 	 * @return void		
- 	 */		
- 	public function update_profile( $user_id ) {	
+	/**
+ 	 * Updates a subscriber's details on profile update.
+ 	 *
+ 	 * @access public
+ 	 * @since 1.2.0
+ 	 * @return void
+ 	 */
+ 	public function update_profile( $user_id, $old_user_data ) {
+		$new_user_data = get_userdata( $user_id );
 
-	 	if ( current_user_can( 'edit_user', $user_id ) ) {
+		// By default only update users if their email has changed.
+		$email_changed = ( $new_user_data->user_email != $old_user_data->user_email );
+		$update_user = $email_changed;
 
-			$user_id = isset( $_REQUEST['user_id'] ) ? intval( $_REQUEST['user_id'] ) : 0;
+		/**
+		 * Filter in case they want to update the user on all updates
+		 *
+		 * @param bool $update_user true or false if user should be updated at Kit
+		 * @param int $user_id ID of user in question
+		 * @param object $old_user_data old data from before this profile update
+		 *
+		 * @since TBD
+		 */
+		$update_user = apply_filters( 'pmpro_kit_update_profile', $update_user, $user_id, $old_user_data );
 
-			if ( ! empty( $user_id ) ) {
+		if ( $update_user ) {
 
-				$user_email = isset( $_REQUEST['email'] ) ? sanitize_email( $_REQUEST['email'] ) : '';
-				$first_name = isset( $_REQUEST['first_name'] ) ? sanitize_text_field( $_REQUEST['first_name'] ) : '';
+			$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', true );
 
-				$subscriber_id = get_user_meta( $user_id, 'pmprock_subscriber_id', true );
+			$subscriber_info = array(
+				'email_address' 	=> $new_user_data->user_email,
+				'first_name' 		=> $new_user_data->first_name,
+				'user_id'			=> $user_id
+			);
 
-				$subscriber_info = array(
-					'email_address' 	=> $user_email,
-					'first_name' 		=> $first_name,
-					'user_id'			=> $user_id
-				);
+			/**
+			 * Filter the subscriber data to add custom fields
+			 *
+			 * @param array $subscriber_info The array containing the subscriber data
+			 */
+			$subscriber_info = apply_filters( 'pmprock_subscriber_update_data', $subscriber_info );
 
-				/**
-				 * Filter the subscriber data to add custom fields 
-				 * 
-				 * @param array $subscriber_info The array containing the subscriber data
-				 */
-				$subscriber_info = apply_filters( 'pmprock_subscriber_update_data', $subscriber_info );
+			// Get the secret API key.
+			$api_secret_key = $this->get_option( 'api-secret-key' );
 
-				// Get the secret API key.
-				$api_secret_key = $this->get_option( 'api-secret-key' );
+			$this->api->update_subscriber( $subscriber_id, $api_secret_key, $subscriber_info );
 
-				$this->api->update_subscriber( $subscriber_id, $api_secret_key, $subscriber_info );
-			}
-
-	 	}
+		}
 
 	}
 

--- a/includes/class-convertkit-pmp.php
+++ b/includes/class-convertkit-pmp.php
@@ -153,8 +153,7 @@ class ConvertKit_PMP {
 		$this->loader->add_action( 'pmpro_checkout_after_tos_fields', $plugin_admin, 'after_tos_fields', 10, 1 );
 		$this->loader->add_action( 'pmpro_paypalexpress_session_vars', $plugin_admin, 'paypalexpress_session_vars', 10, 1 );
 		$this->loader->add_action( 'pmpro_after_checkout', $plugin_admin, 'after_checkout', 10, 2 );
-		$this->loader->add_action( 'personal_options_update', $plugin_admin, 'update_profile', 10, 2 );
-		$this->loader->add_action( 'edit_user_profile_update', $plugin_admin, 'update_profile', 10, 2 );
+		$this->loader->add_action( 'profile_update', $plugin_admin, 'update_profile', 10, 2 );
 		$this->loader->add_action( 'plugin_row_meta', $plugin_admin, 'plugin_row_meta', 10, 2 );
 
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There was code in this Add On to update subscribers in Kit when their profiles in WP were updated.

The code was not working as intended, nor was is hooking into the right WP hook to apply the change whether the profile is updated from the PMPro frontend member edit screen, the admin's Edit Member screen, or the core WP Edit Profile / Edit User screen.

### How to test the changes in this Pull Request:

1. Pull the code
2. Check out for a new membership that would add you to Kit (you must have the usermeta field for the subscriber ID so that the API can find you in Kit.
3. Change a member's email from any screen: frontend member profile edit, edit member, edit profile
4. See that the change is reflected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Now properly updating subscriber profiles in Kit when their WordPress User profile is updated.
* ENHANCEMENT: Added filter `pmpro_kit_update_profile` to update subscribers on all user updates, not just email changes.
